### PR TITLE
Fix for long file names

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -3,6 +3,8 @@ var fs = require('fs')
 	, mkdirp = require('mkdirp')
 	, crypto = require('crypto');
 
+var maxFileSize = 200;
+
 /** Function: storeScreenShot
  * Stores base64 encoded PNG data to the file at the given path.
  *
@@ -11,6 +13,11 @@ var fs = require('fs')
  *     (String) file - Target file path
  */
 function storeScreenShot(data, file) {
+    if (file.length > maxFileSize) {
+        var ext = file.split('.').pop();
+        file = file.substr(0, 200) + ".cut." + ext;
+    }
+
 	var stream = fs.createWriteStream(file);
 
 	stream.write(new Buffer(data, 'base64'));
@@ -28,6 +35,11 @@ function storeScreenShot(data, file) {
 function storeMetaData(metaData, file) {
 	var json
 		, stream;
+
+    if (file.length > maxFileSize) {
+        var ext = file.split('.').pop();
+        file = file.substr(0, 200) + ".cut." + ext;
+    }
 
 	try {
 		json = JSON.stringify(metaData);


### PR DESCRIPTION
This fixes "error: filename too long" error when creating screenshots or .json names longer than the OS (in my case, Xubuntu 14) can handle.

Not sure if it worth it to merge or not.
